### PR TITLE
Update assignees in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_issue_template.yml
@@ -1,8 +1,6 @@
 name: Bug Report
 description: File a bug report
 labels: ['Type: Bug Report']
-assignees:
-  - WillieCubed
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
This PR updates the default assignees in the Bug Report template such that nobody is assigned by default. This can be trivially changed later as needed.