### PR TITLE
Update navbar to only have either hamburger menu or nav buttons

### DIFF
--- a/components/navigation/Navbar.tsx
+++ b/components/navigation/Navbar.tsx
@@ -55,10 +55,12 @@ export default function Navbar() {
     <nav className="flex filter bg-white px-4 py-4 h-20 items-center">
       <MobileNav open={open} setOpen={setOpen} />
       <div className="w-3/12 flex items-center">
-        <Link href="/">
-          <Image src={logo} alt="Jupiter" width={120} height={40}></Image>
+        <Link passHref href="/">
+          <Image src={logo} alt="Jupiter" width={120} height={40} />
         </Link>
-        <NavLink to="/">Explore</NavLink>
+        <div className="hidden md:block">
+          <NavLink to="/">Explore</NavLink>
+        </div>
       </div>
       <div className="w-9/12 flex justify-end items-center">
         <div
@@ -84,11 +86,11 @@ export default function Navbar() {
             }`}
           />
         </div>
-        <NavLink to="/directory">Directory</NavLink>
-        <NavLink to="/events">Events</NavLink>
-        <NavLink to="/about">About</NavLink>
         <div className="hidden md:flex">
-          <Link href="/">
+          <NavLink to="/directory">Directory</NavLink>
+          <NavLink to="/events">Events</NavLink>
+          <NavLink to="/about">About</NavLink>
+          <Link passHref href="/">
             <p className="signUpButton">Sign Up</p>
           </Link>
         </div>


### PR DESCRIPTION
Smaller screens hide the buttons, opting to show the hamburger menu
<img width="797" alt="image" src="https://user-images.githubusercontent.com/76502130/196082655-37904795-431a-4754-9901-962c283b340c.png">
<img width="631" alt="image" src="https://user-images.githubusercontent.com/76502130/196082683-0cd07368-4e80-4b19-adcc-088ce0014da2.png">
