### PR TITLE
More dynamic contact buttons

### DIFF
--- a/components/ContactList.tsx
+++ b/components/ContactList.tsx
@@ -10,12 +10,14 @@ const ContactList: FC<ContactListProps> = ({ contactMethods }) => {
   return (
     <>
       {contactMethods.map((contact, i) => (
+        <a href="https://www.utdnebula.com">
         <div
           key={i}
           className="flex flex-row justify-center items-center p-3 m-3 rounded-2xl bg-gray-200 hover:bg-gray-300 cursor-pointer"
           style={{backgroundColor:(contactStyles[contact] ?? contactStyles["Default"]).bg, color:(contactStyles[contact] ?? contactStyles["Default"]).text}}  >
           <p className="text-2xl font-bold">{contact}</p>
         </div>
+        </a>
       ))}
     </>
   );

--- a/components/ContactList.tsx
+++ b/components/ContactList.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import OrgDirectoryTag from './OrgDirectoryTag';
+import contactStyles from '../contactButtonStyles.json';
 
 interface ContactListProps {
   contactMethods: string[];
@@ -12,7 +13,7 @@ const ContactList: FC<ContactListProps> = ({ contactMethods }) => {
         <div
           key={i}
           className="flex flex-row justify-center items-center p-3 m-3 rounded-2xl bg-gray-200 hover:bg-gray-300 cursor-pointer"
-        >
+          style={{backgroundColor:(contactStyles[contact] ?? contactStyles["Default"]).bg, color:(contactStyles[contact] ?? contactStyles["Default"]).text}}  >
           <p className="text-2xl font-bold">{contact}</p>
         </div>
       ))}

--- a/contactButtonStyles.json
+++ b/contactButtonStyles.json
@@ -1,0 +1,10 @@
+{"Discord":{
+  "bg":"#7289da",
+  "text":"white"
+},
+"Instagram": {
+  "bg":"#E138B6",
+  "text":"white"
+}, "Default":
+{
+}}


### PR DESCRIPTION
This PR enables contact buttons in the org page to be more dynamic. For common contact methods (Discord and Instagram right now) it adds a color to the button. This is structured so that we can easily add new styles later.

It also adds support for linking to external pages when clicking a button.
<img width="1190" alt="Screenshot 2023-02-13 at 1 32 47 PM" src="https://user-images.githubusercontent.com/13911970/218555952-b00f3297-bb17-484f-b02b-e74e15c7f4f3.png">
