### PR TITLE
fix - all club members showing up as officers

### DIFF
--- a/src/server/api/routers/club.ts
+++ b/src/server/api/routers/club.ts
@@ -1,4 +1,4 @@
-import { eq, ilike, sql, and, notInArray, inArray } from 'drizzle-orm';
+import { eq, ilike, sql, and, notInArray, inArray, or } from 'drizzle-orm';
 import { createTRPCRouter, protectedProcedure, publicProcedure } from '../trpc';
 import { z } from 'zod';
 import { selectContact } from '@src/server/db/models';
@@ -241,6 +241,11 @@ export const clubRouter = createTRPCRouter({
           with: {
             contacts: true,
             userMetadataToClubs: {
+              where: (row) =>
+                or(
+                  eq(row.memberType, 'President'),
+                  eq(row.memberType, 'Officer'),
+                ),
               with: {
                 userMetadata: { columns: { firstName: true, lastName: true } },
               },


### PR DESCRIPTION
When I updated the way the directory pages fetch org info, when it would fetch officers it would fetch all members instead of filtering it to only officers. This pr fixes this issue.