### PR TITLE
Add Images to Clubs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,7 +7,11 @@ await import('./src/env.mjs');
 /** @type {import("next").NextConfig} */
 const config = {
   images: {
-    domains: ['lh3.googleusercontent.com', 'cdn.discordapp.com'],
+    domains: [
+      'lh3.googleusercontent.com',
+      'cdn.discordapp.com',
+      'imagedelivery.net',
+    ],
   },
   experimental: {
     serverActions: true,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,7 +10,7 @@ const config = {
     domains: [
       'lh3.googleusercontent.com',
       'cdn.discordapp.com',
-      'imagedelivery.net',
+      'jupiter.nlmc.workers.dev',
     ],
   },
   experimental: {

--- a/src/components/DirectoryOrgs.tsx
+++ b/src/components/DirectoryOrgs.tsx
@@ -5,7 +5,6 @@ import JoinButton from './JoinButton';
 import LikeButton from './LikeButton';
 import Link from 'next/link';
 import { type Session } from 'next-auth';
-import { generateUrl } from '@src/utils/images';
 
 type Props = { club: Club; session: Session | null };
 
@@ -20,7 +19,7 @@ const OrgDirectoryCards: FC<Props> = ({ club, session }) => {
     <div className="flex h-full min-h-[600px] min-w-[300px] max-w-xs flex-col justify-between rounded-lg bg-white shadow-lg">
       <div className="relative h-48 overflow-hidden rounded-t-lg sm:h-56 md:h-64 lg:h-72">
         <Image
-          src={club.profileImage ? generateUrl(club.profileImage) : club.image}
+          src={club.profileImage ? club.profileImage : club.image}
           layout="fill"
           alt={club.name}
           className="select-none object-cover"

--- a/src/components/DirectoryOrgs.tsx
+++ b/src/components/DirectoryOrgs.tsx
@@ -18,7 +18,7 @@ const OrgDirectoryCards: FC<Props> = ({ club, session }) => {
     club.name.length > 20 ? club.name.slice(0, 30) + '...' : club.name;
   return (
     <div className="flex h-full min-h-[600px] min-w-[300px] max-w-xs flex-col justify-between rounded-lg bg-white shadow-lg">
-      <div className="relative h-48 overflow-hidden sm:h-56 md:h-64 lg:h-72">
+      <div className="relative h-48 overflow-hidden rounded-t-lg sm:h-56 md:h-64 lg:h-72">
         <Image
           src={club.profileImage ? generateUrl(club.profileImage) : club.image}
           layout="fill"

--- a/src/components/DirectoryOrgs.tsx
+++ b/src/components/DirectoryOrgs.tsx
@@ -6,9 +6,9 @@ import LikeButton from './LikeButton';
 import Link from 'next/link';
 import { type Session } from 'next-auth';
 
-type Props = { club: Club; session: Session | null };
+type Props = { club: Club; session: Session | null; priority: boolean };
 
-const OrgDirectoryCards: FC<Props> = ({ club, session }) => {
+const OrgDirectoryCards: FC<Props> = ({ club, session, priority }) => {
   const desc =
     club.description.length > 50
       ? club.description.slice(0, 150) + '...'
@@ -22,6 +22,7 @@ const OrgDirectoryCards: FC<Props> = ({ club, session }) => {
           src={club.profileImage ? club.profileImage : club.image}
           layout="fill"
           alt={club.name}
+          priority={priority}
           className="select-none object-cover"
         />
         <div className="absolute left-2 right-2 top-2 flex h-fit flex-row items-center space-x-2">

--- a/src/components/DirectoryOrgs.tsx
+++ b/src/components/DirectoryOrgs.tsx
@@ -5,6 +5,7 @@ import JoinButton from './JoinButton';
 import LikeButton from './LikeButton';
 import Link from 'next/link';
 import { type Session } from 'next-auth';
+import { generateUrl } from '@src/utils/images';
 
 type Props = { club: Club; session: Session | null };
 
@@ -19,7 +20,7 @@ const OrgDirectoryCards: FC<Props> = ({ club, session }) => {
     <div className="flex h-full min-h-[600px] min-w-[300px] max-w-xs flex-col justify-between rounded-lg bg-white shadow-lg">
       <div className="relative h-48 overflow-hidden sm:h-56 md:h-64 lg:h-72">
         <Image
-          src={club.image}
+          src={club.profileImage ? generateUrl(club.profileImage) : club.image}
           layout="fill"
           alt={club.name}
           className="select-none object-cover"

--- a/src/components/DirectoryOrgs.tsx
+++ b/src/components/DirectoryOrgs.tsx
@@ -20,7 +20,7 @@ const OrgDirectoryCards: FC<Props> = ({ club, session, priority }) => {
       <div className="relative h-48 overflow-hidden rounded-t-lg sm:h-56 md:h-64 lg:h-72">
         <Image
           src={club.profileImage ? club.profileImage : club.image}
-          layout="fill"
+          fill
           alt={club.name}
           priority={priority}
           className="select-none object-cover"

--- a/src/components/InfiniteScrollGrid.tsx
+++ b/src/components/InfiniteScrollGrid.tsx
@@ -12,11 +12,11 @@ type Props = {
 export default function InfiniteScrollGrid({ session, tag }: Props) {
   const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
     api.club.all.useInfiniteQuery(
-      { tag, limit: 20 },
+      { tag, limit: 9 },
       {
         getNextPageParam: (lastPage) =>
-          lastPage.clubs.length < 20 ? undefined : lastPage.cursor,
-        initialCursor: 20,
+          lastPage.clubs.length < 9 ? undefined : lastPage.cursor,
+        initialCursor: 9,
       },
     );
 
@@ -57,7 +57,11 @@ export default function InfiniteScrollGrid({ session, tag }: Props) {
                   ref={isLastElement ? lastOrgElementRef : null}
                   key={club.id}
                 >
-                  <DirectoryOrgs club={club} session={session} />
+                  <DirectoryOrgs
+                    club={club}
+                    session={session}
+                    priority={false}
+                  />
                 </div>
               );
             }),

--- a/src/components/OrgDirectoryGrid.tsx
+++ b/src/components/OrgDirectoryGrid.tsx
@@ -10,17 +10,20 @@ interface Props {
 }
 
 const OrgDirectoryGrid: FC<Props> = async ({ tag }) => {
-  const { clubs } = await api.club.all.query({ tag, limit: 20 });
+  const { clubs } = await api.club.all.query({ tag, limit: 9 });
   const session = await getServerAuthSession();
 
   return (
     <div className="flex w-full flex-wrap justify-center gap-16 pb-4">
       {clubs.map((club) => (
-        <DirectoryOrgs key={club.id} club={club} session={session} />
+        <DirectoryOrgs
+          key={club.id}
+          club={club}
+          session={session}
+          priority={true}
+        />
       ))}
-      {clubs.length === 20 && (
-        <InfiniteScrollGrid tag={tag} session={session} />
-      )}
+      {clubs.length === 9 && <InfiniteScrollGrid tag={tag} session={session} />}
       <ScrollTop />
     </div>
   );

--- a/src/components/OrgHeader.tsx
+++ b/src/components/OrgHeader.tsx
@@ -55,7 +55,9 @@ const OrgHeader = async ({ club }: { club: Club }) => {
               <Link
                 href={`/manage/${club.id}`}
                 className="rounded-full bg-blue-primary p-2.5 text-white transition-colors hover:bg-blue-700"
-              >Manage</Link>
+              >
+                Manage
+              </Link>
             ) : (
               <>
                 <JoinButton

--- a/src/components/OrgInfoSegment.tsx
+++ b/src/components/OrgInfoSegment.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import React, { type FC } from 'react';
 import { type RouterOutputs } from '@src/trpc/shared';
+import { generateUrl } from '@src/utils/images';
 
 const OrgInfoSegment: FC<{
   club: NonNullable<RouterOutputs['club']['getDirectoryInfo']>;
@@ -13,7 +14,9 @@ const OrgInfoSegment: FC<{
       <div className="flex flex-col items-start justify-between md:flex-row">
         <div className="pr-12">
           <Image
-            src={club.image}
+            src={
+              club.profileImage ? generateUrl(club.profileImage) : club.image
+            }
             alt="Picture of the club"
             width={100}
             height={100}

--- a/src/components/OrgInfoSegment.tsx
+++ b/src/components/OrgInfoSegment.tsx
@@ -1,7 +1,6 @@
 import Image from 'next/image';
 import React, { type FC } from 'react';
 import { type RouterOutputs } from '@src/trpc/shared';
-import { generateUrl } from '@src/utils/images';
 
 const OrgInfoSegment: FC<{
   club: NonNullable<RouterOutputs['club']['getDirectoryInfo']>;
@@ -14,9 +13,7 @@ const OrgInfoSegment: FC<{
       <div className="flex flex-col items-start justify-between md:flex-row">
         <div className="pr-12">
           <Image
-            src={
-              club.profileImage ? generateUrl(club.profileImage) : club.image
-            }
+            src={club.profileImage ? club.profileImage : club.image}
             alt="Picture of the club"
             width={100}
             height={100}

--- a/src/server/db/migrations/0001_next_marrow.sql
+++ b/src/server/db/migrations/0001_next_marrow.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "club" ADD COLUMN "profile_image" text;

--- a/src/server/db/migrations/meta/0001_snapshot.json
+++ b/src/server/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,620 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "829b275c-a72c-4e19-9481-7e3dffc23d7d",
+  "prevId": "f2b17a86-7372-4ddf-b655-0758889c36ab",
+  "tables": {
+    "club": {
+      "name": "club",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nanoid(20)"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/nebula-logo.png'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "platform": {
+          "name": "platform",
+          "type": "platform",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contacts_club_id_club_id_fk": {
+          "name": "contacts_club_id_club_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "club",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contacts_platform_club_id": {
+          "name": "contacts_platform_club_id",
+          "columns": [
+            "platform",
+            "club_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nanoid(20)"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_club_id_club_id_fk": {
+          "name": "events_club_id_club_id_fk",
+          "tableFrom": "events",
+          "tableTo": "club",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId": {
+          "name": "account_provider_providerAccountId",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "user_metadata": {
+      "name": "user_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "major": {
+          "name": "major",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minor": {
+          "name": "minor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "year",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "career": {
+          "name": "career",
+          "type": "career",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "user_metadata_to_clubs": {
+      "name": "user_metadata_to_clubs",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_type": {
+          "name": "member_type",
+          "type": "member_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_metadata_to_clubs_user_id_user_metadata_id_fk": {
+          "name": "user_metadata_to_clubs_user_id_user_metadata_id_fk",
+          "tableFrom": "user_metadata_to_clubs",
+          "tableTo": "user_metadata",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_metadata_to_clubs_club_id_club_id_fk": {
+          "name": "user_metadata_to_clubs_club_id_club_id_fk",
+          "tableFrom": "user_metadata_to_clubs",
+          "tableTo": "club",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_metadata_to_clubs_user_id_club_id": {
+          "name": "user_metadata_to_clubs_user_id_club_id",
+          "columns": [
+            "user_id",
+            "club_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "user_metadata_to_events": {
+      "name": "user_metadata_to_events",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_metadata_to_events_user_id_user_id_fk": {
+          "name": "user_metadata_to_events_user_id_user_id_fk",
+          "tableFrom": "user_metadata_to_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_metadata_to_events_event_id_events_id_fk": {
+          "name": "user_metadata_to_events_event_id_events_id_fk",
+          "tableFrom": "user_metadata_to_events",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_metadata_to_events_user_id_event_id": {
+          "name": "user_metadata_to_events_user_id_event_id",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token": {
+          "name": "verificationToken_identifier_token",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "career": {
+      "name": "career",
+      "values": {
+        "Healthcare": "Healthcare",
+        "Art and Music": "Art and Music",
+        "Engineering": "Engineering",
+        "Business": "Business",
+        "Sciences": "Sciences",
+        "Public Service": "Public Service"
+      }
+    },
+    "member_type": {
+      "name": "member_type",
+      "values": {
+        "President": "President",
+        "Officer": "Officer",
+        "Member": "Member"
+      }
+    },
+    "role": {
+      "name": "role",
+      "values": {
+        "Student": "Student",
+        "Student Organizer": "Student Organizer",
+        "Administrator": "Administrator"
+      }
+    },
+    "year": {
+      "name": "year",
+      "values": {
+        "Freshman": "Freshman",
+        "Sophomore": "Sophomore",
+        "Junior": "Junior",
+        "Senior": "Senior",
+        "Grad Student": "Grad Student"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/src/server/db/migrations/meta/_journal.json
+++ b/src/server/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1702076289386,
       "tag": "0000_slimy_lifeguard",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1706223814646,
+      "tag": "0001_next_marrow",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/schema/club.ts
+++ b/src/server/db/schema/club.ts
@@ -15,6 +15,7 @@ export const club = pgTable('club', {
     .array()
     .default(sql`'{}'::text[]`)
     .notNull(),
+  profileImage: text('profile_image'),
 });
 
 export const clubRelations = relations(club, ({ many }) => ({

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -1,2 +1,0 @@
-export const generateUrl = (id: string) =>
-  `https://imagedelivery.net/nvIk9L9uOncJbjAmZIj7rQ/${id}/public`;

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -1,0 +1,2 @@
+export const generateUrl = (id: string) =>
+  `https://imagedelivery.net/nvIk9L9uOncJbjAmZIj7rQ/${id}/public`;


### PR DESCRIPTION
Uses a cloudflare r2 bucket to host club images from soc data, shows up in the directory and in the info segment.

Also adds a new column for the profile image, fallbacks to the image column when there isn’t a profile image.