### PR TITLE
fix: auth redirects not working right on prod

### DIFF
--- a/src/trpc/shared.ts
+++ b/src/trpc/shared.ts
@@ -2,14 +2,9 @@ import { type inferRouterInputs, type inferRouterOutputs } from '@trpc/server';
 import superjson from 'superjson';
 
 import { type AppRouter } from '@src/server/api/root';
+import { getBaseUrl } from '@src/utils/redirect';
 
 export const transformer = superjson;
-
-function getBaseUrl() {
-  if (typeof window !== 'undefined') return '';
-  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
-  return `http://localhost:${process.env.PORT ?? 3000}`;
-}
 
 export function getUrl() {
   return getBaseUrl() + '/api/trpc';

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -1,7 +1,8 @@
-import { env } from '@src/env.mjs';
-
 export function signInRoute(route: string) {
-  return `/auth?callbackUrl=${encodeURIComponent(
-    `${env.NEXTAUTH_URL}/${route}`,
-  )}`;
+  return `/auth?callbackUrl=${encodeURIComponent(`${getBaseUrl()}/${route}`)}`;
+}
+export function getBaseUrl() {
+  if (typeof window !== 'undefined') return '';
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+  return `http://localhost:${process.env.PORT ?? 3000}`;
 }


### PR DESCRIPTION
switched to using the baseURL function instead of the nextauth_url, was causing issues because it didn't have `https://` and so it treated it as a path instead of a full url and that's what broke the redirect.