### PR TITLE
fix: use headers to determine base url for auth redirect

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -31,4 +31,3 @@ const Settings = async () => {
 };
 
 export default Settings;
-3;

--- a/src/trpc/shared.ts
+++ b/src/trpc/shared.ts
@@ -2,10 +2,13 @@ import { type inferRouterInputs, type inferRouterOutputs } from '@trpc/server';
 import superjson from 'superjson';
 
 import { type AppRouter } from '@src/server/api/root';
-import { getBaseUrl } from '@src/utils/redirect';
 
 export const transformer = superjson;
-
+function getBaseUrl() {
+  if (typeof window !== 'undefined') return '';
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+  return `http://localhost:${process.env.PORT ?? 3000}`;
+}
 export function getUrl() {
   return getBaseUrl() + '/api/trpc';
 }

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -1,8 +1,9 @@
+import { headers } from 'next/headers';
+
 export function signInRoute(route: string) {
-  return `/auth?callbackUrl=${encodeURIComponent(`${getBaseUrl()}/${route}`)}`;
-}
-export function getBaseUrl() {
-  if (typeof window !== 'undefined') return '';
-  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
-  return `http://localhost:${process.env.PORT ?? 3000}`;
+  const host = headers().get('X-Forwarded-Host');
+  const proto = headers().get('X-Forwarded-Proto');
+  return `/auth?callbackUrl=${encodeURIComponent(
+    `${proto}://${host}/${route}`,
+  )}`;
 }


### PR DESCRIPTION
unfortunate that it's taken so many attempts, good learning though.
now using the `X-Forwarded-host` and `X-Forwarded-proto` headers to determine what the url the client is using is and follow that. unfortunately really only testable in prod.