### PR TITLE
JUP-84 tag improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ $$;
 Currently, drizzle does not automatically create enums for you. You will have to create them manually. This [link](https://orm.drizzle.team/docs/column-types/pg#enum) should give you a good idea of how to create enums in postgres.
 
 </details> </br>
+<details>
+<summary>Tag View</summary>
+  there is a sql query in `src/server/db/tagView.sql` that you need to run in order for tags to work properly.
+</details>
 
 Once you have added the `DATABASE_URL` to your `.env` file, and have all the necessary extensions as well as enums, you will need to run the following commands to create the tables in your database.
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Currently, drizzle does not automatically create enums for you. You will have to
 <details>
 <summary>Tag View</summary>
   there is a sql query in `src/server/db/tagView.sql` that you need to run in order for tags to work properly.
+  This query sets up a view that queries the different tags from clubs and orders them by how many clubs have those tags in descending order.
 </details></br>
 
 Once you have added the `DATABASE_URL` to your `.env` file, and have all the necessary extensions as well as enums, you will need to run the following commands to create the tables in your database.

--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ $$;
 
 Currently, drizzle does not automatically create enums for you. You will have to create them manually. This [link](https://orm.drizzle.team/docs/column-types/pg#enum) should give you a good idea of how to create enums in postgres.
 
-</details> </br>
+</details> 
 <details>
 <summary>Tag View</summary>
   there is a sql query in `src/server/db/tagView.sql` that you need to run in order for tags to work properly.
-</details>
+</details></br>
 
 Once you have added the `DATABASE_URL` to your `.env` file, and have all the necessary extensions as well as enums, you will need to run the following commands to create the tables in your database.
 

--- a/src/server/api/routers/club.ts
+++ b/src/server/api/routers/club.ts
@@ -14,7 +14,7 @@ import { z } from 'zod';
 import { selectContact } from '@src/server/db/models';
 import { clubEditRouter } from './clubEdit';
 import { userMetadataToClubs } from '@src/server/db/schema/users';
-import { club } from '@src/server/db/schema/club';
+import { club, usedTags } from '@src/server/db/schema/club';
 import { contacts } from '@src/server/db/schema/contacts';
 import { carousel } from '@src/server/db/schema/admin';
 const byNameSchema = z.object({
@@ -119,14 +119,10 @@ export const clubRouter = createTRPCRouter({
   }),
   distinctTags: publicProcedure.query(async ({ ctx }) => {
     try {
-      const tags = await ctx.db.selectDistinct({ tags: club.tags }).from(club);
-      const tagSet = new Set<string>(['All']);
-      tags.forEach((club) => {
-        club.tags.forEach((tag) => {
-          tagSet.add(tag);
-        });
-      });
-      return Array.from(tagSet);
+      const tags = (await ctx.db.select().from(usedTags)).map(
+        (obj) => obj.tags,
+      );
+      return tags;
     } catch (e) {
       console.error(e);
       return [];

--- a/src/server/db/schema/club.ts
+++ b/src/server/db/schema/club.ts
@@ -1,5 +1,12 @@
 import { relations, sql } from 'drizzle-orm';
-import { boolean, pgEnum, pgTable, text } from 'drizzle-orm/pg-core';
+import {
+  boolean,
+  integer,
+  pgEnum,
+  pgTable,
+  pgView,
+  text,
+} from 'drizzle-orm/pg-core';
 import { events } from './events';
 import { userMetadataToClubs } from './users';
 import { contacts } from './contacts';
@@ -35,3 +42,8 @@ export const clubRelations = relations(club, ({ many }) => ({
   userMetadataToClubs: many(userMetadataToClubs),
   carousel: many(carousel),
 }));
+
+export const usedTags = pgView('used_tags', {
+  tags: text('tags').notNull(),
+  count: integer('count').notNull(),
+}).existing();

--- a/src/server/db/tagView.sql
+++ b/src/server/db/tagView.sql
@@ -1,0 +1,6 @@
+select distinct UNNEST(tags) as tags,
+count(tags)
+from
+club
+group by unnest(tags)
+order by count desc


### PR DESCRIPTION
this pr introduces a new database view that lets us see all the unique tags and how many clubs there are for each tag, it's default ordering is also by count. This new ordering also applies to the tag listing on the homepage. 

we may want to switch it to a materialized view with triggers as this information shouldn't be updated often, as view can't be indexed in postgres.