### PR TITLE
Jup 141 typesafe helpers for cloud storage api

### DIFF
--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -4,6 +4,7 @@ import { eventRouter } from './routers/event';
 import { userMetadataRouter } from './routers/userMetadata';
 import { formRouter } from './routers/form';
 import { adminRouter } from './routers/admin';
+import { storageRouter } from './routers/storage';
 
 /**
  * This is the primary router for your server.
@@ -16,6 +17,7 @@ export const appRouter = createTRPCRouter({
   userMetadata: userMetadataRouter,
   form: formRouter,
   admin: adminRouter,
+  storage: storageRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/storage.ts
+++ b/src/server/api/routers/storage.ts
@@ -1,0 +1,75 @@
+import { createTRPCRouter, publicProcedure, protectedProcedure } from '../trpc';
+import { z } from 'zod';
+
+const getDeleteSchema = z.object({
+  objectID: z.string(),
+});
+
+const postSchema = z.object({
+  objectID: z.string(),
+  data: z.string(),
+});
+
+interface GetPostResponse {
+  bucket: string;
+  name: string;
+  content_type: string;
+  size: number;
+  content_encoding: '';
+  md5: string;
+  media_link: string;
+  created: string;
+  updated: string;
+}
+
+type DeleteResponse = 1;
+
+type APIResponse<T> =
+  | {
+      message: 'success';
+      status: number;
+      data: T;
+    }
+  | {
+      message: 'error';
+      status: number;
+      data: string;
+    };
+
+async function callStorageAPI<T>(
+  method: 'GET' | 'POST' | 'DELETE',
+  objectID: string,
+  body?: string,
+): Promise<T> {
+  const res = await fetch(
+    `${process.env.NEBULA_API_URL}/storage/${process.env.NEBULA_API_STORAGE_BUCKET}/${objectID}`,
+    {
+      method,
+      headers: {
+        'x-api-key': process.env.NEBULA_API_KEY as string,
+        'x-storage-key': process.env.NEBULA_API_STORAGE_KEY as string,
+      },
+      ...(body && { body }),
+    },
+  );
+
+  const data = (await res.json()) as APIResponse<T>;
+
+  if (data.message !== 'success') {
+    throw new Error(data.data);
+  }
+
+  return data.data;
+}
+
+export const storageRouter = createTRPCRouter({
+  get: publicProcedure.input(getDeleteSchema).query(async ({ input }) => {
+    return callStorageAPI<GetPostResponse>('GET', input.objectID);
+  }),
+  delete: protectedProcedure.input(getDeleteSchema).query(async ({ input }) => {
+    return callStorageAPI<GetPostResponse>('DELETE', input.objectID);
+  }),
+  post: protectedProcedure.input(postSchema).query(async ({ input }) => {
+    return callStorageAPI<DeleteResponse>('POST', input.objectID, input.data);
+  }),
+});


### PR DESCRIPTION
Based off of #283 

Here are some basic wrappers on the the APIs cloud storage endpoints. I'm new to this tRPC stuff so lmk any changes to make.

I think I could have zod do runtime response type checking if we want. And I'm not sure how we want to do error handling, as in if it's ok for an error to just be thrown in the router.