### PR TITLE
fix: Infinite scroll breaking on changing tags

### DIFF
--- a/src/components/club/directory/InfiniteScrollGrid.tsx
+++ b/src/components/club/directory/InfiniteScrollGrid.tsx
@@ -14,7 +14,7 @@ type Props = {
 export default function InfiniteScrollGrid({ session }: Props) {
   const { search, tag } = useSearchStore((state) => state);
   const api = useTRPC();
-  const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
+  const { data, isLoading, isFetchingNextPage, fetchNextPage } =
     useInfiniteQuery(
       api.club.all.infiniteQueryOptions(
         { name: search, tag, limit: 9 },
@@ -30,16 +30,14 @@ export default function InfiniteScrollGrid({ session }: Props) {
   const lastClubElementRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (isLoading || isFetchingNextPage) return;
-
-    if (observer.current) observer.current.disconnect();
-
-    observer.current = new IntersectionObserver((entries) => {
-      if (!entries[0]) return;
-      if (entries[0].isIntersecting) {
-        void fetchNextPage();
-      }
-    });
+    if (observer.current == undefined) {
+      observer.current = new IntersectionObserver((entries) => {
+        if (!entries[0]) return;
+        if (entries[0].isIntersecting) {
+          void fetchNextPage();
+        }
+      });
+    }
 
     if (lastClubElementRef.current) {
       observer.current.observe(lastClubElementRef.current);
@@ -48,7 +46,7 @@ export default function InfiniteScrollGrid({ session }: Props) {
     return () => {
       if (observer.current) observer.current.disconnect();
     };
-  }, [isLoading, isFetchingNextPage, hasNextPage, fetchNextPage]);
+  }, [fetchNextPage, data]);
 
   return (
     <>


### PR DESCRIPTION
There was a bug where upon switching to an already fetched query, this was caused by a misconfigured dependency array.