### PR TITLE
Create PillButton component

### DIFF
--- a/src/app/manage/[clubId]/(dashboard)/page.tsx
+++ b/src/app/manage/[clubId]/(dashboard)/page.tsx
@@ -4,7 +4,7 @@ import { EyeIcon, PlusIcon, PencilIcon, GroupIcon, PersonIcon } from '@src/icons
 const Page = ({ params }: { params: { clubId: string } }) => {
   return (
     <>
-      <div className="flex flex-row gap-10 rounded-lg bg-white p-2 shadow-xs">
+      <div className="flex flex-row flex-wrap gap-x-10 gap-y-4 rounded-lg bg-white p-2 shadow-xs">
         <PillButton
           href={`/manage/${params.clubId}/edit`}
           IconComponent={PencilIcon}

--- a/src/app/manage/[clubId]/(dashboard)/page.tsx
+++ b/src/app/manage/[clubId]/(dashboard)/page.tsx
@@ -1,28 +1,28 @@
 import PillButton from '@src/components/PillButton';
-import { EyeIcon, PlusIcon } from '@src/icons/Icons';
-import Link from 'next/link';
+import { EyeIcon, PlusIcon, PencilIcon, GroupIcon, PersonIcon } from '@src/icons/Icons';
 
 const Page = ({ params }: { params: { clubId: string } }) => {
   return (
     <>
-      <div className="flex flex-row gap-x-1 rounded-lg bg-white p-2 shadow-xs">
-        <Link
+      <div className="flex flex-row gap-10 rounded-lg bg-white p-2 shadow-xs">
+        <PillButton
           href={`/manage/${params.clubId}/edit`}
-          className="bg-blue-primary rounded-md p-1 font-semibold text-white"
+          IconComponent={PencilIcon}
         >
           Edit Club Data
-        </Link>
-        <Link
+        </PillButton>
+        <PillButton
           href={`/manage/${params.clubId}/edit/officers`}
-          className="bg-blue-primary rounded-md p-1 font-semibold text-white"
+          IconComponent={PersonIcon}
         >
           Manage Officers
-        </Link>
-        <button className="bg-blue-primary rounded-md p-1 font-semibold text-white">
+        </PillButton>
+        <PillButton IconComponent={GroupIcon} disabled>
           View members
-        </button>
-
-        <PillButton IconComponent={EyeIcon}>View Events</PillButton>
+        </PillButton>
+        <PillButton IconComponent={EyeIcon} disabled>
+          View Events
+        </PillButton>
         <PillButton
           href={`/manage/${params.clubId}/create`}
           IconComponent={PlusIcon}

--- a/src/app/manage/[clubId]/(dashboard)/page.tsx
+++ b/src/app/manage/[clubId]/(dashboard)/page.tsx
@@ -1,3 +1,5 @@
+import PillButton from '@src/components/PillButton';
+import { EyeIcon, PlusIcon } from '@src/icons/Icons';
 import Link from 'next/link';
 
 const Page = ({ params }: { params: { clubId: string } }) => {
@@ -19,12 +21,14 @@ const Page = ({ params }: { params: { clubId: string } }) => {
         <button className="bg-blue-primary rounded-md p-1 font-semibold text-white">
           View members
         </button>
-        <Link
+
+        <PillButton IconComponent={EyeIcon}>View Events</PillButton>
+        <PillButton
           href={`/manage/${params.clubId}/create`}
-          className="bg-blue-primary rounded-md p-1 font-semibold text-white"
+          IconComponent={PlusIcon}
         >
           Create Event
-        </Link>
+        </PillButton>
       </div>
     </>
   );

--- a/src/components/PillButton.tsx
+++ b/src/components/PillButton.tsx
@@ -94,7 +94,8 @@ const PillButton = ({
         ${colors[color ?? 'default']?.bg ?? 'bg-blue-primary'}
         ${colors[color ?? 'default']?.hover ?? 'hover:bg-blue-700'}
         ${colors[color ?? 'default']?.text ?? 'text-white'}
-        disabled:bg-slate-700 disabled:text-white disabled:cursor-not-allowed`;
+        disabled:bg-slate-700 disabled:text-white disabled:cursor-not-allowed
+        min-w-max`;
 
   const contents = (
     <div

--- a/src/components/PillButton.tsx
+++ b/src/components/PillButton.tsx
@@ -1,0 +1,130 @@
+import Link from 'next/link';
+import type { IconType } from 'src/icons/Icons';
+
+const defaultColors = {
+  bg: 'bg-blue-primary',
+  hover: 'hover:bg-blue-700',
+  text: 'text-white',
+};
+
+// // Annoyingly, I couldn't get PillButtonColor to work so that it'd make the
+// // `color` property in `PillButtonProps` to be a union of the keys in `colors`
+// // instead of `string | undefined`... ugh TypeScript is a fake language
+//
+// type PillButtonColor = {
+//   bg: string;
+//   hover: string;
+//   text: string;
+// };
+// const colors: Record<string, PillButtonColor> = {
+
+const colors = {
+  default: defaultColors,
+  blue: defaultColors,
+  red: {
+    bg: 'bg-persimmon-500',
+    hover: 'hover:bg-red-700',
+    text: 'text-white',
+  },
+  orange: {
+    bg: 'bg-events',
+    hover: 'hover:bg-orange-700',
+    text: 'text-white',
+  },
+  green: {
+    bg: 'bg-green-600',
+    hover: 'hover:bg-green-700',
+    text: 'text-white',
+  },
+};
+
+type colorsKeys = keyof typeof colors;
+
+type PillButtonPropsBase = {
+  children?: string;
+  IconComponent?: IconType;
+  color?: colorsKeys;
+  size?: 'default' | 'large';
+};
+
+interface PillButtonPropsAsButton extends PillButtonPropsBase {
+  onClick?: React.MouseEventHandler;
+  href?: never;
+}
+
+interface PillButtonPropsAsLink extends PillButtonPropsBase {
+  onClick?: never;
+  href?: string;
+}
+
+type PillButtonProps = PillButtonPropsAsButton | PillButtonPropsAsLink;
+
+/**
+ * **Component for a default pill button. Children will be displayed as the button's text.**
+ * - If provided with `onClick`, will return a button.
+ * - If provided with `href`, will return a link.
+ *
+ * @param {React.MouseEventHandler} onClick - Event handler that is run when button is clicked
+ * @param {IconType} IconComponent - An icon component from Icons.tsx
+ * @param {colorsKeys} color - A valid item from the list of pre-defined colors for the pill button
+ * @param {PillButtonProps["size"]} size - "default" | "large"
+ *
+ * @example <caption>Example of button text</caption>
+ * <PillButton>Text</PillButton>
+ *
+ * @example <caption>Example of an icon-only button</caption>
+ * <PillButton IconComponent={PlusIcon}></PillButton>
+ *
+ * @example <caption>Example of a link button</caption>
+ * <PillButton href="https://example.com">Link</PillButton>
+ */
+const PillButton = ({
+  children,
+  onClick,
+  href,
+  IconComponent,
+  color,
+  size,
+}: PillButtonProps) => {
+  const childrenClasses = ` 
+        rounded-full cursor-pointer transition-colors text-s font-bold 
+        ${colors[color ?? 'default']?.bg ?? 'bg-blue-primary'}
+        ${colors[color ?? 'default']?.hover ?? 'hover:bg-blue-700'}
+        ${colors[color ?? 'default']?.text ?? 'text-white'}
+        disabled:bg-slate-700 disabled:text-white disabled:cursor-not-allowed`;
+
+  const contents = (
+    <div
+      className={`flex flex-row items-center justify-center ${
+        size == 'large'
+          ? 'h-12.5 min-w-12.5 px-3.75 py-2.5'
+          : 'h-10.5 min-w-10.5 px-2.75 py-1.5'
+      }`}
+    >
+      {children ? (
+        <span className="px-2 pb-0.5 leading-7">{children}</span>
+      ) : (
+        ''
+      )}
+      {IconComponent ? (
+        <div className="flex h-5 w-5 items-center justify-center">
+          {IconComponent && <IconComponent fill={'white'} size={16} />}
+        </div>
+      ) : (
+        ''
+      )}
+    </div>
+  );
+
+  return href ? (
+    <Link className={childrenClasses} href={href}>
+      {contents}
+    </Link>
+  ) : (
+    <button className={childrenClasses} onClick={onClick}>
+      {contents}
+    </button>
+  );
+};
+
+export default PillButton;

--- a/src/components/PillButton.tsx
+++ b/src/components/PillButton.tsx
@@ -50,11 +50,13 @@ type PillButtonPropsBase = {
 interface PillButtonPropsAsButton extends PillButtonPropsBase {
   onClick?: React.MouseEventHandler;
   href?: never;
+  disabled?: boolean;
 }
 
 interface PillButtonPropsAsLink extends PillButtonPropsBase {
   onClick?: never;
   href?: string;
+  disabled?: never;
 }
 
 type PillButtonProps = PillButtonPropsAsButton | PillButtonPropsAsLink;
@@ -85,6 +87,7 @@ const PillButton = ({
   IconComponent,
   color,
   size,
+  disabled,
 }: PillButtonProps) => {
   const childrenClasses = ` 
         rounded-full cursor-pointer transition-colors text-s font-bold 
@@ -102,7 +105,7 @@ const PillButton = ({
       }`}
     >
       {children ? (
-        <span className="px-2 pb-0.5 leading-7">{children}</span>
+        <span className="px-2 leading-8">{children}</span>
       ) : (
         ''
       )}
@@ -121,7 +124,7 @@ const PillButton = ({
       {contents}
     </Link>
   ) : (
-    <button className={childrenClasses} onClick={onClick}>
+    <button className={childrenClasses} onClick={onClick} disabled={disabled}>
       {contents}
     </button>
   );

--- a/src/icons/Icons.tsx
+++ b/src/icons/Icons.tsx
@@ -239,13 +239,16 @@ export const PlusIcon: IconType = ({ fill = defaultFill }) => (
     />
   </svg>
 );
-export const GroupIcon: IconType = () => (
+export const GroupIcon: IconType = ({
+  fill = defaultFill,
+  size = defaultSize,
+}) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="auto"
-    height="auto"
+    width={size}
+    height={size}
     viewBox="0 0 30 30"
-    fill="none"
+    fill={fill}
   >
     <path
       fillRule="evenodd"
@@ -335,6 +338,10 @@ export const ExpandLess = () => (
     />
   </svg>
 );
+
+/**
+ * Note: AccountIcon is a less dynamic version of PersonIcon. Please replace all instances of AccountIcon with PersonIcon
+ */
 export const AccountIcon = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -348,6 +355,23 @@ export const AccountIcon = () => (
       clipRule="evenodd"
       d="M15 15C17.21 15 19 13.21 19 11C19 8.79 17.21 7 15 7C12.79 7 11 8.79 11 11C11 13.21 12.79 15 15 15ZM15 17C12.33 17 7 18.34 7 21V22C7 22.55 7.45 23 8 23H22C22.55 23 23 22.55 23 22V21C23 18.34 17.67 17 15 17Z"
       fill="#C3CAD9"
+    />
+  </svg>
+);
+
+export const PersonIcon = ({ fill = defaultFill, size = defaultSize }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size * 1.5}
+    height={size * 1.5}
+    viewBox="0 0 30 30"
+    fill="none"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M15 15C17.21 15 19 13.21 19 11C19 8.79 17.21 7 15 7C12.79 7 11 8.79 11 11C11 13.21 12.79 15 15 15ZM15 17C12.33 17 7 18.34 7 21V22C7 22.55 7.45 23 8 23H22C22.55 23 23 22.55 23 22V21C23 18.34 17.67 17 15 17Z"
+      fill={fill}
     />
   </svg>
 );
@@ -434,6 +458,26 @@ export const EyeIcon: IconType = ({
       fill-rule="evenodd"
       clip-rule="evenodd"
       d="m 8.000006,3.0000065 c -3.33333,0 -6.18,2.073337 -7.333332,4.999997 1.153332,2.9266705 4.000002,4.9999905 7.333332,4.9999905 3.33332,0 6.18002,-2.07332 7.33332,-4.9999905 -1.1533,-2.92666 -4,-4.999997 -7.33332,-4.999997 z m 0,8.3333375 c -1.84,0 -3.33333,-1.4933405 -3.33333,-3.3333405 0,-1.84 1.49333,-3.33333 3.33333,-3.33333 1.84,0 3.33332,1.49333 3.33332,3.33333 0,1.84 -1.49332,3.3333405 -3.33332,3.3333405 z m 0,-5.3333405 c -1.10667,0 -2,0.89334 -2,2 0,1.10667 0.89333,2.0000005 2,2.0000005 1.10667,0 2.00002,-0.8933305 2.00002,-2.0000005 0,-1.10666 -0.89335,-2 -2.00002,-2 z"
+      fill={fill}
+    />
+  </svg>
+);
+
+export const PencilIcon: IconType = ({
+  fill = defaultFill,
+  size = defaultSize,
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 27 28"
+    fill={fill}
+  >
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M0 22.1937V26.7537C0 27.1737 0.33 27.5037 0.75 27.5037H5.31C5.505 27.5037 5.7 27.4287 5.835 27.2787L22.215 10.9137L16.59 5.28873L0.225 21.6537C0.075 21.8037 0 21.9837 0 22.1937ZM26.565 6.56373C27.15 5.97873 27.15 5.03373 26.565 4.44873L23.055 0.938728C22.7748 0.657849 22.3943 0.5 21.9975 0.5C21.6007 0.5 21.2202 0.657849 20.94 0.938728L18.195 3.68373L23.82 9.30873L26.565 6.56373Z"
       fill={fill}
     />
   </svg>

--- a/src/icons/Icons.tsx
+++ b/src/icons/Icons.tsx
@@ -1,8 +1,9 @@
 import { type FC } from 'react';
 
-export type IconType = FC<{ fill?: string }>;
+export type IconType = FC<{ fill?: string; size?: number }>;
 const defaultFill = 'fill-slate-400';
 const defaultHeartFill = 'fill-slate-800';
+const defaultSize = 24;
 
 export const HomeIcon: IconType = ({ fill = defaultFill }) => (
   <svg
@@ -415,6 +416,25 @@ export const DownArrowIcon = ({ className }: { className: string }) => (
       clip-rule="evenodd"
       d="M13.5925 8V19.17L8.7125 14.29C8.3225 13.9 7.6825 13.9 7.2925 14.29C6.9025 14.68 6.9025 15.31 7.2925 15.7L13.8825 22.29C14.2725 22.68 14.9025 22.68 15.2925 22.29L21.8825 15.7C22.2725 15.31 22.2725 14.68 21.8825 14.29C21.6957 14.1027 21.442 13.9975 21.1775 13.9975C20.913 13.9975 20.6593 14.1027 20.4725 14.29L15.5925 19.17V8C15.5925 7.45 15.1425 7 14.5925 7C14.0425 7 13.5925 7.45 13.5925 8Z"
       fill="#FFFFFF"
+    />
+  </svg>
+);
+export const EyeIcon: IconType = ({
+  fill = defaultFill,
+  size = defaultSize,
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill={fill}
+  >
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="m 8.000006,3.0000065 c -3.33333,0 -6.18,2.073337 -7.333332,4.999997 1.153332,2.9266705 4.000002,4.9999905 7.333332,4.9999905 3.33332,0 6.18002,-2.07332 7.33332,-4.9999905 -1.1533,-2.92666 -4,-4.999997 -7.33332,-4.999997 z m 0,8.3333375 c -1.84,0 -3.33333,-1.4933405 -3.33333,-3.3333405 0,-1.84 1.49333,-3.33333 3.33333,-3.33333 1.84,0 3.33332,1.49333 3.33332,3.33333 0,1.84 -1.49332,3.3333405 -3.33332,3.3333405 z m 0,-5.3333405 c -1.10667,0 -2,0.89334 -2,2 0,1.10667 0.89333,2.0000005 2,2.0000005 1.10667,0 2.00002,-0.8933305 2.00002,-2.0000005 0,-1.10666 -0.89335,-2 -2.00002,-2 z"
+      fill={fill}
     />
   </svg>
 );


### PR DESCRIPTION
Resolves #304 

> [!WARNING]
> I wasn't able to test this because I'm not on the team and thus don't have the environment variables. So please test this PR before merging lol

Created a PillButton component. You can use it as both an HTML `<button>` and a Next.js `<Link>` by simply specifying either an `onClick` or `href` property, respectively.
- Can be text-only, icon-only, both, or even neither (not sure why you'd need that)
- Has pre-defined colors. Currently has default/blue, red, orange, and green. Also supports hover states and disabled buttons.
  - You can add more colors by adding to the `colors` constant in `PillButton.tsx`

Demo of the different styles of pill buttons:
<img width="1159" height="529" alt="image" src="https://github.com/user-attachments/assets/24eb58f7-d70b-4254-b510-8cf82faf735b" />


Demo of pill buttons for the club event management page:
<img width="478" height="106" alt="image" src="https://github.com/user-attachments/assets/f3c8e24b-b628-4a95-ac90-9de4247ebe72" />