### PR TITLE
added placeholder for loading club images

### DIFF
--- a/src/components/club/ClubCard.tsx
+++ b/src/components/club/ClubCard.tsx
@@ -13,7 +13,8 @@ const ClubCard: FC<Props> = ({ club, session, priority }) => {
       ? club.description.slice(0, 150) + '...'
       : club.description;
   const name =
-    club.name.length > 20 ? club.name.slice(0, 30) + '...' : club.name;
+    club.name.length > 20 ? club.name.slice(0, 30) + '...' : club.name;       
+  const placeholderImage = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAAQABADAREAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAABgf/xAAXEAEAAwAAAAAAAAAAAAAAAAAFACIx/8QAGAEAAgMAAAAAAAAAAAAAAAAABAUGBwj/xAAWEQADAAAAAAAAAAAAAAAAAAAAAgT/2gAMAwEAAhEDEQA/ALuYnlpkZHL4onFpieWhaOI6JySlqZaKEcnNMwtMTy0MRxFROf/Z"
   return (
     <div className="flex h-full min-h-[400px] max-w-xs min-w-[300px] flex-col justify-between rounded-lg bg-white shadow-2xl md:min-h-[600px]">
       <div className="relative h-48 overflow-hidden rounded-t-lg sm:h-56 md:h-64 lg:h-72">
@@ -25,6 +26,8 @@ const ClubCard: FC<Props> = ({ club, session, priority }) => {
             priority={priority}
             sizes="20rem"
             className="object-cover select-none"
+            placeholder='blur'
+            blurDataURL={placeholderImage}
           />
         ) : (
           <div className="absolute inset-0 h-full w-full bg-gray-200" />


### PR DESCRIPTION
This change resolves #305 by adding placeholder for loading club image.

Base64 image could be changed in the future to better fit the desired design schema.