### PR TITLE
Search Bar Anchor to Top of Screen

### DIFF
--- a/src/components/searchBar/HomePageSearch.tsx
+++ b/src/components/searchBar/HomePageSearch.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import type { SelectClub as Club } from '@src/server/db/models';
 import { useTRPC } from '@src/trpc/react';
@@ -26,11 +26,36 @@ export const HomePageSearchBar = () => {
   const onClickSearchResult = (club: Club) => {
     router.push(`/directory/${club.slug}`);
   };
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isSticky, setIsSticky] = useState(false);
+  const originalOffset = useRef<number>(0); 
+
   useEffect(() => {
     updateSearch(debouncedSearch);
   }, [debouncedSearch, updateSearch]);
+
+  useEffect(() => {
+    if (containerRef.current) { 
+      originalOffset.current =
+        containerRef.current.getBoundingClientRect().top + window.scrollY;
+    }
+  const handleScroll = () => {
+    const scrollY = window.scrollY;
+    setIsSticky(scrollY > (originalOffset.current)); 
+  };
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
   return (
-    <div className="relative mr-3 w-full max-w-xs text-shadow-[0_0_4px_rgb(0_0_0_/_0.4)] md:max-w-sm lg:max-w-md">
+    <div
+      ref={containerRef}
+      className={`mr-3 w-full max-w-xs text-shadow-... md:max-w-sm lg:max-w-md transition-all ${
+        isSticky
+          ? 'fixed top-0 z-50 justify-center' 
+          : 'relative'
+      }`}
+    >
       <SearchBar
         placeholder="Search for Clubs"
         tabIndex={0}


### PR DESCRIPTION
Home page search bar becomes sticky to the top of the screen when the user scrolls past it.

<img width="2879" height="1450" alt="image" src="https://github.com/user-attachments/assets/6800fe08-2000-4ad2-904c-816099642631" />



Possible improvements:
- Make search bar hang below the top rather than right on the edge. Needs a smooth transition or a way to hide the drop as you scroll past.
- Make search bar function at any point on the page, rather than jumping to the top when a query is typed
