### PR TITLE
Remove "Description" header from club card

### DIFF
--- a/src/components/club/ClubCard.tsx
+++ b/src/components/club/ClubCard.tsx
@@ -38,7 +38,6 @@ const ClubCard: FC<Props> = ({ club, session, priority }) => {
         <h1 className="line-clamp-1 text-2xl font-medium text-slate-800 md:text-xl">
           {name}
         </h1>
-        <p className="text-sm text-slate-500 md:text-xs">Description</p>
         <p className="text-base text-slate-600 md:text-sm">{desc}</p>
       </div>
       <div className="m-5 mt-auto flex flex-row space-x-2">


### PR DESCRIPTION
Resolves issue #329 
Removed the unnecessary "Description" header text that was displayed on club cards between the title and the actual description.

Old:
<img width="220" height="404" alt="image" src="https://github.com/user-attachments/assets/ff6ea281-e2af-49ac-a1d7-29381bfc0d68" />

New:
<img width="220" height="404" alt="image" src="https://github.com/user-attachments/assets/0567a194-e9fb-4221-85a1-6f3901f1f010" />
